### PR TITLE
fix(isInSubnet): Throw errors on invalid subnet IPs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ export { IPv4, IPv6 };
  * Test if the given IP address is contained in the specified subnet.
  * @param address the IPv4 or IPv6 address to check
  * @param subnet the IPv4 or IPv6 CIDR to test (or an array of them)
- * @throws if any of the address or subnet(s) are not valid IP addresses, or the CIDR prefix length
- *  is not valid
+ * @throws if any of the address or subnet(s) are not valid IP addresses, or the CIDR
+ *  prefix length is not valid
  */
 export function isInSubnet(address: string, subnetOrSubnets: string | string[]): boolean {
   if (!Array.isArray(subnetOrSubnets)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,9 @@ export function isInSubnet(address: string, subnetOrSubnets: string | string[]):
   if (!Array.isArray(subnetOrSubnets)) {
     return isInSubnet(address, [subnetOrSubnets]);
   }
-
+  if (!util.isIP(address)) {
+    throw new Error(`not a valid IPv4 or IPv6 address: ${address}`);
+  }
   const subnetsByVersion = subnetOrSubnets.reduce(
     (acc, subnet) => {
       const ip = subnet.split('/')[0];

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,10 +40,8 @@ export function isInSubnet(address: string, subnetOrSubnets: string | string[]):
 
   if (util.isIPv6(address)) {
     return IPv6.isInSubnet(address, subnetsByVersion[6]);
-  } else if (util.isIPv4(address)) {
-    return IPv4.isInSubnet(address, subnetsByVersion[4]);
   } else {
-    throw new Error(`address is not valid as v4 or v6: ${address}`);
+    return IPv4.isInSubnet(address, subnetsByVersion[4]);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,10 @@ export function isInSubnet(address: string, subnetOrSubnets: string | string[]):
 
   if (util.isIPv6(address)) {
     return IPv6.isInSubnet(address, subnetsByVersion[6]);
-  } else {
+  } else if (util.isIPv4(address)) {
     return IPv4.isInSubnet(address, subnetsByVersion[4]);
+  } else {
+    throw new Error(`address is not valid as v4 or v6: ${address}`);
   }
 }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -83,4 +83,17 @@ describe('general tests', () => {
     assert.strictEqual(isSpecial('::'), true);
     assert.strictEqual(isSpecial('::ffff:127.0.0.1'), true);
   });
+
+  it('should throw on invalid subnets', () => {
+    assert.throws(() => isInSubnet('1.3.3.4', '1.352352352/32'));
+    assert.throws(() =>
+      isInSubnet('::ffff:1.3.3.4', '11:22:33:44:55:66:77:88:99:1010/32')
+    );
+    assert.throws(() =>
+      isInSubnet(
+        '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        '11:22:33:44:55:66:77:88:99:1010/32'
+      )
+    );
+  });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -96,4 +96,9 @@ describe('general tests', () => {
       )
     );
   });
+
+  it('should throw on invalid addresses', () => {
+    assert.throws(() => isInSubnet('1.2.233333.4', '2001:db8::/32'));
+    assert.throws(() => isInSubnet('11:22:33:44:55', '2001:db8::/32'));
+  });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -83,6 +83,7 @@ describe('general tests', () => {
     assert.strictEqual(isSpecial('::'), true);
     assert.strictEqual(isSpecial('::ffff:127.0.0.1'), true);
   });
+
   it('should throw on invalid IPs', () => {
     assert.throws(() => isInSubnet('1.2.233333.4', '2001:db8::/32'));
     assert.throws(() => isInSubnet('11:22:33:44:55', '2001:db8::/32'));
@@ -90,6 +91,8 @@ describe('general tests', () => {
     assert.throws(() =>
       isInSubnet('11:22:33:44:55:66:77:88:99:1010', '2001:db8:f53a::1:1/64')
     );
+  });
+
   it('should throw on invalid subnets', () => {
     assert.throws(() => isInSubnet('1.3.3.4', '1.352352352/32'));
     assert.throws(() =>

--- a/test/index.ts
+++ b/test/index.ts
@@ -96,9 +96,4 @@ describe('general tests', () => {
       )
     );
   });
-
-  it('should throw on invalid addresses', () => {
-    assert.throws(() => isInSubnet('1.2.233333.4', '2001:db8::/32'));
-    assert.throws(() => isInSubnet('11:22:33:44:55', '2001:db8::/32'));
-  });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -83,7 +83,13 @@ describe('general tests', () => {
     assert.strictEqual(isSpecial('::'), true);
     assert.strictEqual(isSpecial('::ffff:127.0.0.1'), true);
   });
-
+  it('should throw on invalid IPs', () => {
+    assert.throws(() => isInSubnet('1.2.233333.4', '2001:db8::/32'));
+    assert.throws(() => isInSubnet('11:22:33:44:55', '2001:db8::/32'));
+    assert.throws(() => isInSubnet('1.352352352', '0.0.0.0/0'));
+    assert.throws(() =>
+      isInSubnet('11:22:33:44:55:66:77:88:99:1010', '2001:db8:f53a::1:1/64')
+    );
   it('should throw on invalid subnets', () => {
     assert.throws(() => isInSubnet('1.3.3.4', '1.352352352/32'));
     assert.throws(() =>


### PR DESCRIPTION
- Ensure `isInSubnet` throws if any of the given subnets lack valid IP addresses

Fixes #6 