### PR TITLE
Add functional checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ console.log(isInSubnet.check('10.5.0.1', '10.4.5.0/16'));
 const inAnySubnet = isInSubnet('10.5.0.1', ['10.4.5.0/16', '192.168.1.0/24']);
 ```
 
+### Amortise the parsing cost using a functional version
+
+- `createChecker(subnetOrSubnets)` returns a function used to check an address
+
+```javascript
+const checker = createChecker(['10.4.5.0/16', '192.168.1.0/24']);
+console.log(checker('10.5.0.1')); // true
+```
+
 ### Test for special types of addresses
 
 - `isPrivate(address)` — Private addresses (like `192.168.0.0`)

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -13,6 +13,16 @@ Test if the given IP address is contained in the specified subnet.
 
 Will `throw` an `Error` if the address or subnet are not valid IP addresses, or the CIDR prefix length is not valid.
 
+Or the functional version:
+
+`createChecker(subnetOrSubnets: string | string[]): (address: string) => boolean`
+
+Create a function from one or more subnet, to check an if an address belongs to any of them.
+
+When checking many subnets together many times, it pays to amortise as much of the upfront processing as possible. 
+
+This functional version will `throw` an `Error` if the subnet(s) given are invalid, and the returned function will `throw` an if the given address is not valid.
+
 ## Checking if a string represents a valid IP address
 
 * `isIPv4(s: string): boolean`

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,21 @@ export { IPv4, IPv6 };
  *  prefix length is not valid
  */
 export function isInSubnet(address: string, subnetOrSubnets: string | string[]): boolean {
+  return createChecker(subnetOrSubnets)(address);
+}
+/**
+ * Create a function to test if the given IP address is contained in the specified subnet.
+ * @param subnet the IPv4 or IPv6 CIDR to test (or an array of them)
+ * @throws if any of the subnet(s) are not valid IP addresses, or the CIDR
+ *  prefix length is not valid
+ */
+export function createChecker(
+  subnetOrSubnets: string | string[]
+): (address: string) => boolean {
   if (!Array.isArray(subnetOrSubnets)) {
-    return isInSubnet(address, [subnetOrSubnets]);
+    return createChecker([subnetOrSubnets]);
   }
-  if (!util.isIP(address)) {
-    throw new Error(`not a valid IPv4 or IPv6 address: ${address}`);
-  }
+
   const subnetsByVersion = subnetOrSubnets.reduce(
     (acc, subnet) => {
       const ip = subnet.split('/')[0];
@@ -32,19 +41,24 @@ export function isInSubnet(address: string, subnetOrSubnets: string | string[]):
     throw new Error(`some subnets are not valid IP addresses: ${subnetsByVersion[0]}`);
   }
 
-  // for mapped IPv4 addresses, compare against both IPv6 and IPv4 subnets
-  if (util.isIPv6(address) && IPv6.isIPv4MappedAddress(address)) {
-    return (
-      IPv6.isInSubnet(address, subnetsByVersion[6]) ||
-      IPv4.isInSubnet(IPv6.extractMappedIpv4(address), subnetsByVersion[4])
-    );
-  }
+  const check4 = IPv4.createChecker(subnetsByVersion[4]);
+  const check6 = IPv6.createChecker(subnetsByVersion[6]);
 
-  if (util.isIPv6(address)) {
-    return IPv6.isInSubnet(address, subnetsByVersion[6]);
-  } else {
-    return IPv4.isInSubnet(address, subnetsByVersion[4]);
-  }
+  return address => {
+    if (!util.isIP(address)) {
+      throw new Error(`not a valid IPv4 or IPv6 address: ${address}`);
+    }
+    // for mapped IPv4 addresses, compare against both IPv6 and IPv4 subnets
+    if (util.isIPv6(address) && IPv6.isIPv4MappedAddress(address)) {
+      return check6(address) || check4(IPv6.extractMappedIpv4(address));
+    }
+
+    if (util.isIPv6(address)) {
+      return check6(address);
+    } else {
+      return check4(address);
+    }
+  };
 }
 
 /** Test if the given IP address is a private/internal IP address. */

--- a/src/ipv4.ts
+++ b/src/ipv4.ts
@@ -81,32 +81,29 @@ function createLongChecker(subnet: string): (addressLong: number) => boolean {
 
 // cache these special subnet checkers
 const specialNetsCache: Record<string, (address: string) => boolean> = {};
-function getSpecialChecker(
-  kind: 'private' | 'localhost' | 'reserved' | 'special'
-): (address: string) => boolean {
-  if (kind in specialNetsCache === false) {
-    const subnets =
-      kind === 'special'
-        ? [...ipRange.private.ipv4, ...ipRange.localhost.ipv4, ...ipRange.reserved.ipv4]
-        : ipRange[kind].ipv4;
-    specialNetsCache[kind] = createChecker(subnets);
-  }
-  return specialNetsCache[kind];
-}
 
 /** Test if the given IP address is a private/internal IP address. */
 export function isPrivate(address: string) {
-  return getSpecialChecker('private')(address);
+  if ('private' in specialNetsCache === false) {
+    specialNetsCache['private'] = createChecker(ipRange.private.ipv4);
+  }
+  return specialNetsCache['private'](address);
 }
 
 /** Test if the given IP address is a localhost address. */
 export function isLocalhost(address: string) {
-  return getSpecialChecker('localhost')(address);
+  if ('localhost' in specialNetsCache === false) {
+    specialNetsCache['localhost'] = createChecker(ipRange.localhost.ipv4);
+  }
+  return specialNetsCache['localhost'](address);
 }
 
 /** Test if the given IP address is in a known reserved range and not a normal host IP */
 export function isReserved(address: string) {
-  return getSpecialChecker('reserved')(address);
+  if ('reserved' in specialNetsCache === false) {
+    specialNetsCache['reserved'] = createChecker(ipRange.reserved.ipv4);
+  }
+  return specialNetsCache['reserved'](address);
 }
 
 /**
@@ -114,5 +111,12 @@ export function isReserved(address: string) {
  * localhost)
  */
 export function isSpecial(address: string) {
-  return getSpecialChecker('special')(address);
+  if ('special' in specialNetsCache === false) {
+    specialNetsCache['special'] = createChecker([
+      ...ipRange.private.ipv4,
+      ...ipRange.localhost.ipv4,
+      ...ipRange.reserved.ipv4
+    ]);
+  }
+  return specialNetsCache['special'](address);
 }

--- a/test/performance.ts
+++ b/test/performance.ts
@@ -15,6 +15,13 @@ describe('performance', function() {
   // tests in this suite can take a moment, don’t warn about that
   this.slow(4000);
 
+  // we keep this cache outside the tests, as it should be global
+  // but we reset it each time.
+  let checkerCache: Map<string, ReturnType<typeof createChecker>>;
+  this.beforeEach(() => {
+    checkerCache = new Map();
+  });
+
   it('should be able to test 100,000 ipv4 addresses in less than 4 seconds', () => {
     // approximately 100K test runs
     const cycleCount = Math.floor(100_000 / ipv4fixtures.length);
@@ -50,9 +57,6 @@ describe('performance', function() {
     const average = Math.floor((cycleCount * ipv6fixtures.length) / friendlyElapsed);
     console.log(`average IPv6 performance was ${average.toLocaleString()} per second`);
   });
-
-  // we keep this cache outside the tests, as it should be global
-  const checkerCache = new Map<string, ReturnType<typeof createChecker>>();
 
   it('should be able to test 100,000 ipv4 addresses in less than 4 seconds using `createChecker`', () => {
     // approximately 100K test runs


### PR DESCRIPTION
This allows creating the checking function up front, amortising
the cost of parsing the subnets for each check.

My use case for use this library was as part of a webserver and I have
a list of subnets and I check every request. Performance is greatly
improved by caching the checking function up front.

This adds a negligible overhead to the existing one-shot process for
single subnets, a tiny increase in performance for the one-shot process
with multiple subnets and a large increase when repeatedly rechecking
the same subnet.

The performance tests have been updated as well to show the difference.

On my system they show a marked increase:

```
  performance
average IPv4 performance was 1,152,440 per second
    ✓ should be able to test 100,000 ipv4 addresses in less than 4 seconds
average IPv6 performance was 426,176 per second
    ✓ should be able to test 100,000 ipv6 addresses in less than 4 seconds
average IPv4 performance was 3,936,143 per second (cached checker)
    ✓ should be able to test 100,000 ipv4 addresses in less than 4 seconds using `createChecker`
average IPv6 performance was 805,719 per second (cached checker)
    ✓ should be able to test 100,000 ipv6 addresses in less than 4 seconds using `createChecker`
```